### PR TITLE
Add JavaScript/Markdown formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+insert_final_newline = true
+# Supported by some editors/formatters:
+trim_trailing_whitespace = true
+end_of_line = lf
+indent_style = space
+indent_size = 4
+max_line_length = 100

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,3 @@
+arrowParens = "avoid"
+quoteProps = "consistent"
+singleQuote = false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Typst-Automatic-Translation
+
 Translate English on the typst.app into other languages.
 
 ## Usage
@@ -9,3 +10,13 @@ Since the program is currently in an early version, the only way to use it at th
 - Added support for switching other languages;
 - Stop monitoring while editing text until you finish editing;
 - Lower uptime and storage.
+
+## Development
+
+### Formatting
+
+Formatting is done with [`prettier`](https://prettier.io):
+
+```sh
+prettier -w i
+```

--- a/typst-automatic-translation.user.js
+++ b/typst-automatic-translation.user.js
@@ -9,8 +9,8 @@
 // @grant        none
 // ==/UserScript==
 
-(function() {
-    'use strict';
+(function () {
+    "use strict";
     const ChineseTranslation = {
         "About Typst": "关于Typst",
         "Account settings": "账户设置",
@@ -61,8 +61,8 @@
         "Tutorial": "教程",
         "Undo": "撤销",
         "Upload file": "上传文件",
-        "View": "视图"
-    }
+        "View": "视图",
+    };
     const Translation = ChineseTranslation;
     function translateFragment(fragment) {
         const newText = Translation[fragment.innerText];
@@ -77,20 +77,20 @@
         if (headerButtons) {
             headerButtons.forEach(button => {
                 translateFragment(button);
-            })
+            });
         }
-        const menus = document.querySelectorAll("ul[role=menu]")
+        const menus = document.querySelectorAll("ul[role=menu]");
         menus.forEach(menu => {
-            const menuItems = menu.querySelectorAll("li[role=menuitem]")
+            const menuItems = menu.querySelectorAll("li[role=menuitem]");
             if (menuItems) {
                 menuItems.forEach(item => {
                     const span = item.querySelector("span");
                     if (span) {
                         translateFragment(span);
                     }
-                })
+                });
             }
-        })
+        });
         const h1 = document.querySelector("h1");
         if (h1) {
             translateFragment(h1);
@@ -108,11 +108,11 @@
             const strongs = projectListHeader.querySelectorAll("strong");
             strongs.forEach(strong => {
                 translateFragment(strong);
-            })
+            });
             const spans = projectListHeader.querySelectorAll("span");
             spans.forEach(span => {
                 translateFragment(span);
-            })
+            });
         }
         observer.observe(document.body, { childList: true, subtree: true });
     }


### PR DESCRIPTION
Working without formatting is really hard. Prettier is the go-to formatter for JS. I made the config so that there are as little changes as possible. Except for...well, inconsistencies.

Added `.editorconfig` for a more universal/portable basic formatting. Although a few options are only available in more concrete config, like the one for Prettier. Which apparently also formats Markdown. Not sure if this is a bad thing.
