### PR TITLE
Include pre-commit hook in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Translate English on the typst.app into other languages.
 
 ## Usage
+
 Since the program is currently in an early version, the only way to use it at this time is to manually download the source file from GitHub. This means you need to check for updates manually.
 
 ## Issues to be addressed (help welcome):
+
 - increase the number of entries;
 - Added support for switching other languages;
 - Stop monitoring while editing text until you finish editing;
@@ -13,10 +15,28 @@ Since the program is currently in an early version, the only way to use it at th
 
 ## Development
 
-### Formatting
+### Prerequisites
 
-Formatting is done with [`prettier`](https://prettier.io):
+- [`prettier`](https://prettier.io) (for file formatting)
+
+Add pre-commit Git hook after cloning this repository:
 
 ```sh
-prettier -w i
+cat << EOF > .git/hooks/pre-commit
+#!/bin/sh
+if ! prettier -c .; then
+  prettier -w .
+  echo "Files were re-formatted. Please commit these changes." >&2
+  false
+fi
+EOF
+chmod +x .git/hooks/pre-commit
+```
+
+### Formatting
+
+Formatting is done with `prettier`:
+
+```sh
+prettier -w .
 ```


### PR DESCRIPTION
Pre-commit hook will keep all developers in check. All committed code should be formatted, after creating the hook. There are some pre-commit CLIs, but I think they are unnecessary.
